### PR TITLE
Упрощение публикации в хаб

### DIFF
--- a/.github/workflow/release.yml
+++ b/.github/workflow/release.yml
@@ -12,4 +12,4 @@ jobs:
     with:
       package_mask: "tokenizer-*.ospx"
     secrets:
-      PUSH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+      PUSH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Отдельный пуш токен больше не нужен